### PR TITLE
Fix Privilege#equals method

### DIFF
--- a/src/main/java/org/baeldung/persistence/model/Privilege.java
+++ b/src/main/java/org/baeldung/persistence/model/Privilege.java
@@ -75,10 +75,10 @@ public class Privilege {
             return false;
         }
         final Privilege privilege = (Privilege) obj;
-        if (!privilege.equals(privilege.name)) {
-            return false;
+        if (name == null) {
+            return privilege.name == null;
         }
-        return true;
+        return name.equals(privilege.name);
     }
 
     @Override


### PR DESCRIPTION
`privilege.equals(privilege.name)`
A Privilege object never equals a String object